### PR TITLE
Update `simple_asn1` to fix RUSTSEC-2020-0159

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ simple_asn1 = "0.6"
 [dev-dependencies]
 openssl = "0.10"
 rand = "0.6" # the `rsa` crate insists on using an old version of `rand`
-rsa = "0.1"
+rsa = "0.5"
 num-bigint-dig = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["crypto", "cryptography", "rsa", "der"]
 categories = ["cryptography"]
 
 [dependencies]
-simple_asn1 = "0.4"
+simple_asn1 = "0.6"
 
 [dev-dependencies]
 openssl = "0.10"


### PR DESCRIPTION
Issued caused by the no longer maintained `chrono` crate has caused many dependencies to switch to the `time` crate.